### PR TITLE
Do nothing when dealing with an empty child

### DIFF
--- a/lib/slack_transformer/html/paragraph.rb
+++ b/lib/slack_transformer/html/paragraph.rb
@@ -34,6 +34,9 @@ module SlackTransformer
             child.replace("#{newline}#{children_html}")
             previous = is_empty ? EMPTY_P_TAG : P_TAG
           else
+            # Do nothing if dealing with an empty child.
+            next if child.content.strip.empty?
+
             current = child.name
             # Only add new line if previous element is a p tag AND we are not within a list.
             newline = previous == P_TAG && parent.name != LI_TAG ? NEWLINE : EMPTY

--- a/spec/slack_transformer/html/paragraph_spec.rb
+++ b/spec/slack_transformer/html/paragraph_spec.rb
@@ -84,5 +84,12 @@ RSpec.describe SlackTransformer::Html::Paragraph do
           expect(transformation.to_slack).to eq("Test\n• Bullet 1\n\t• Nested Bullet <a>Link</a>")
         end
       end
+
+      context 'Ignore empty content' do
+        let(:input) { "<p>Hello</p> <p>World</p>"}
+        it 'Only add one newline between' do
+          expect(transformation.to_slack).to eq("Hello \nWorld")
+        end
+      end
     end
   end


### PR DESCRIPTION
Given this html
```
html = <<~HTML_MESSAGE.squish
 <p><strong>Bold</strong> and <em>Italic</em></p>
 <p>
   <strong><em>Bold and Italic</em></strong>
 </p>
 <ul>
   <li>
     <p>List <strong>Option</strong> 1</p>
     <p>Multiline</p>
     <ul>
       <li>
         <p><em>Nested</em></p>
         <p>
           Multiline <strong><em>Option</em></strong>
         </p>
       </li>
       <li>
         <p>
           Nested option with
           <a
             target="_blank"
             rel="noopener noreferrer nofollow"
             href="https://test.com"
             >link</a
           >
         </p>
       </li>
     </ul>
   </li>
 </ul>
HTML_MESSAGE
```

Before: 
```
"*Bold* and _Italic_\n \n *_Bold and Italic_* \n <ul> <li> \nList *Option* 1 \nMultiline <ul> <li> \n_Nested_ \n Multiline *_Option_*  </li> <li> \n Nested option with <a href=\"https://test.com\">link</a>  </li> </ul> </li> </ul>"
```

After:
```
"*Bold* and _Italic_ \n *_Bold and Italic_*  \n<ul> <li> List *Option* 1 \nMultiline <ul> <li> _Nested_ \n Multiline *_Option_*  </li> <li>  Nested option with <a href=\"https://test.com\">link</a>  </li> </ul> </li> </ul>"
```